### PR TITLE
Fix errors caused by whitespace in the shebang.

### DIFF
--- a/bootstrap_namespace_prefixer.py
+++ b/bootstrap_namespace_prefixer.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 """ Add a configurable prefix to the specified css and js Bootstrap files (also work with minified version)
 @author Francois Aucamp <francois.aucamp@gmail.com>
 @license GPLv2+


### PR DESCRIPTION
The space character after the hash # was causing errors in bash when executing the script directly.